### PR TITLE
Fixed error which prevented logging and added timestamp pattern

### DIFF
--- a/elasticsearch_indexer.go
+++ b/elasticsearch_indexer.go
@@ -36,6 +36,7 @@ func NewElasticsearchIndexer(baseurl string) *ElasticsearchIndexer {
 }
 
 func (ei *ElasticsearchIndexer) Process(l *LogEntry) error {
+	l.wg.Wait()
 	ei.fanout <- l
 	return nil
 }

--- a/log_parser_test.go
+++ b/log_parser_test.go
@@ -32,6 +32,10 @@ func Test_getPosAndPatternForTime(t *testing.T) {
 	a.NoError(err)
 	a.Equal(1, i)
 
+	i, _, err = getPosAndPatternForTime([]string{"foo", "2018-02-22T08:27:14Z", "bar"})
+	a.NoError(err)
+	a.Equal(1, i)
+
 	i, _, err = getPosAndPatternForTime([]string{"foo", "29/May/2016:16:23:08 +0200", "bar"})
 	a.NoError(err)
 	a.Equal(1, i)

--- a/main.go
+++ b/main.go
@@ -166,6 +166,7 @@ func read(reader io.Reader, processor Processor) (count, ignoreCount, errorCount
 			fmt.Printf("\n%v\n%+v\n", line, l)
 		}
 		//fmt.Printf("%v %v %v\n", l.verb, l.ContentType, l.path)
+		l.wg.Add(1)
 		if err := processor.Process(l); err != nil {
 			panic(err)
 		}

--- a/user_simulation.go
+++ b/user_simulation.go
@@ -90,7 +90,6 @@ func (us *UserSimulation) doCall(client *http.Client, l *LogEntry) {
 
 	l.Replay.ErrorMessage = fmt.Sprintf("%v", resp.StatusCode)
 	l.Replay.DurationMs = int(time.Since(l.Timestamp).Nanoseconds() / 1000000)
-
 	if resp.StatusCode != l.Response {
 		l.Replay.Error = true
 		l.Replay.ErrorMessage = fmt.Sprintf("Wrong status returned: %v (expected: %v)", resp.StatusCode, l.Response)
@@ -110,9 +109,8 @@ loop:
 			if l.ContentType == "ignore" {
 				continue
 			}
-			lCopy := *l
-			us.doCall(client, &lCopy)
-			us.log.Process(&lCopy)
+			us.doCall(client, l)
+			l.wg.Done()
 		case <-shouldFinishC:
 			break loop
 		}


### PR DESCRIPTION
Race conditions are now prevented. A log entry in elasticsearch_indexer will only be created when the request has been executed.